### PR TITLE
Fixes for FreeBSD build

### DIFF
--- a/generated-tests/CMakeLists.txt
+++ b/generated-tests/CMakeLists.txt
@@ -21,13 +21,16 @@ foreach(TEST_SUITE ${WASM_TESTS}) # create an independent target for each test s
     string(REPLACE "\n" ";" SN_LIST ${SUITE_NAME})
     foreach(SN ${SN_LIST})
       foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
-          add_test(NAME ${SN}_unit_test_${RUNTIME} COMMAND wasm_spec_test --run_test=${SN} --report_level=detailed --color_output --catch_system_errors=no -- --${RUNTIME})
-          set_property(TEST ${SN}_unit_test_${RUNTIME} PROPERTY LABELS wasm_spec_tests)
-          # build list of tests to run during coverage testing
-          if(ctest_tests)
-              string(APPEND ctest_tests "|")
+          get_test_property(${SN}_unit_test_${RUNTIME} LABELS TEST_LABEL)
+          if ("NOTFOUND" STREQUAL "${TEST_LABEL}") # prevent duplicates
+            add_test(NAME ${SN}_unit_test_${RUNTIME} COMMAND wasm_spec_test --run_test=${SN} --report_level=detailed --color_output --catch_system_errors=no -- --${RUNTIME})
+            set_property(TEST ${SN}_unit_test_${RUNTIME} PROPERTY LABELS wasm_spec_tests)
+            # build list of tests to run during coverage testing
+            if(ctest_tests)
+                string(APPEND ctest_tests "|")
+            endif()
+            string(APPEND ctest_tests "${SN}_unit_test_${RUNTIME}")
           endif()
-          string(APPEND ctest_tests "${SN}_unit_test_${RUNTIME}")
       endforeach()
     endforeach(SN)
   endif()


### PR DESCRIPTION
Added validation of whether test with some name was already added. This can happen due to grepping of *.cpp files and will result in hard error on BSD