### PR TITLE
[3.2] wasm-spec-tests: fix build when path has spaces

### DIFF
--- a/generated-tests/CMakeLists.txt
+++ b/generated-tests/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories( wasm_spec_test PUBLIC
 
 ### MARK TEST SUITES FOR EXECUTION ###
 foreach(TEST_SUITE ${WASM_TESTS}) # create an independent target for each test suite
-  execute_process(COMMAND bash -c "grep -Eo 'BOOST_DATA_TEST_CASE\\(\\w*' ${TEST_SUITE} | cut -c 22-" OUTPUT_VARIABLE SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file
+  execute_process(COMMAND bash -c "grep -Eo 'BOOST_DATA_TEST_CASE\\(\\w*' '${TEST_SUITE}' | cut -c 22-" OUTPUT_VARIABLE SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file
   if (NOT "" STREQUAL "${SUITE_NAME}") # ignore empty lines
     string(REPLACE "\n" ";" SN_LIST ${SUITE_NAME})
     foreach(SN ${SN_LIST})


### PR DESCRIPTION
Backport https://github.com/EOSIO/eosio-wasm-spec-tests/pull/11
Resolve submodule part of https://github.com/eosnetworkfoundation/mandel/issues/424

Fix build when path has spaces