### PR TITLE
Add ENF license information to main branch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,11 @@
-Copyright (c) 2021 block.one and its contributors.  All rights reserved.
+eosnetworkfoundation/mandel-wasm-spec-tests
+
+Copyright (c) 2021-2022 EOS Network Foundation (ENF) and its contributors.  All rights reserved. 
+This ENF software is based upon:
+
+EOSIO/eosio-wasm-spect-tests
+
+Copyright (c) 2019 block.one and its contributors.  All rights reserved.
 
 The MIT License
 


### PR DESCRIPTION
Resolve https://github.com/eosnetworkfoundation/mandel-wasm-spec-tests/issues/4.

ENF license information was added to `v2.0.x`. Port the same information to `main` branch.